### PR TITLE
Add OnlineStatsBase Interface

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,7 +1,12 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.7.3"
+julia_version = "1.7.2"
 manifest_format = "2.0"
+
+[[deps.AbstractTrees]]
+git-tree-sha1 = "03e0550477d86222521d254b741d470ba17ea0b5"
+uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+version = "0.3.4"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -9,9 +14,67 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "9489214b993cd42d17f44c36e359bf6a7c919abf"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.15.0"
+
+[[deps.ChangesOfVariables]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
+git-tree-sha1 = "1e315e3f4b0b7ce40feded39c73049692126cf53"
+uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+version = "0.1.3"
+
+[[deps.Compat]]
+deps = ["Dates", "LinearAlgebra", "UUIDs"]
+git-tree-sha1 = "924cdca592bc16f14d2f7006754a621735280b74"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.1.0"
+
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+[[deps.DataAPI]]
+git-tree-sha1 = "fb5f5316dd3fd4c5e7c30a24d50643b73e37cd40"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.10.0"
+
+[[deps.DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "d1fff3a548102f48987a52a2e0d114fa97d730f0"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.13"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.6"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "336cc738f03e069ef2cac55a104eb823455dca75"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.4"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.1"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -20,13 +83,93 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
+[[deps.LogExpFunctions]]
+deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "09e4b894ce6a976c354a69041a04748180d43637"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.15"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[deps.Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "bf210ce90b6c9eed32d25dbcae1ebc565df2687f"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.0.2"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[deps.OnlineStatsBase]]
+deps = ["AbstractTrees", "Dates", "LinearAlgebra", "OrderedCollections", "Statistics", "StatsBase"]
+git-tree-sha1 = "287bd0f7ee1cc2a73f08057a7a6fcfe0c23fe4b0"
+uuid = "925886fa-5bf2-5e8e-b522-a9147a512338"
+version = "1.4.9"
+
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.1"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "b3363d7460f7d098ca0912c69b082f75625d7508"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.0.1"
+
+[[deps.SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.StatsAPI]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "c82aaa13b44ea00134f8c9c89819477bd3986ecd"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.3.0"
+
+[[deps.StatsBase]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "8977b17906b0a1cc74ab2e3a05faa16cf08a8291"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.33.16"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,3 +6,5 @@ version = "0.1.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+OnlineStatsBase = "925886fa-5bf2-5e8e-b522-a9147a512338"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/TDigest.jl
+++ b/src/TDigest.jl
@@ -203,6 +203,10 @@ end
 
 OnlineStatsBase.nobs(digest::MergingDigest) = sum(x -> x.count, digest.sketch, init=0)
 
+OnlineStatsBase.value(o::MergingDigest) = o
+
+Base.show(io::IO, o::MergingDigest) = print(io, "MergingDigest: n=", nobs(o))
+
 mergeNewValues!(digest::MergingDigest, force::Bool, compression) =
     mergeNewValues!(digest, digest.sketch, digest.log, force, compression)
 

--- a/src/TDigest.jl
+++ b/src/TDigest.jl
@@ -3,6 +3,8 @@ module TDigest
 using Markdown
 using LinearAlgebra
 
+import Statistics: quantile
+using OnlineStatsBase
 
 
 struct Centroid{T, K}
@@ -14,7 +16,7 @@ Base.isless(a::Centroid{T, K}, b::Centroid{T, K}) where {T, K} = a.mean < b.mean
 
 include("scale.jl")
 
-md""" 
+md"""
 Maintains a t-digest by collecting new points in a buffer that
 is then sorted occasionally and merged into a sorted array that
 contains previously computed centroids.
@@ -50,17 +52,17 @@ worthwhile since even with the overhead, the memory cost is less than
 40 bytes per centroid which is much less than half what the
 AVLTreeDigest uses and no dynamic allocation is required at all.
 """
-struct MergingDigest{T, K} 
+struct MergingDigest{T, K} <: OnlineStat{Number}
     function MergingDigest{T1,K1}(public::Real, private::Real,
                                   scale::ScaleFunction, maxSize::Int,
-                                  logData::Bool) where {T1, K1} 
+                                  logData::Bool) where {T1, K1}
         new{T1, K1}(public, private, scale,
-                    maxSize, 
+                    maxSize,
                     logData, Vector{Vector{T1}}(), [0],
                     Vector{Centroid{T1, K1}}(),
                     [0], true, true)
     end
-    
+
     publicCompression::Float64
     privateCompression::Float64
     scale::ScaleFunction
@@ -71,7 +73,7 @@ struct MergingDigest{T, K}
     # these hold a record of all samples we have seen
     logData::Bool
     log::Vector{Vector{T}}
-    
+
     # sum_i weight[i]
     totalWeight::Vector{K}
 
@@ -89,19 +91,19 @@ struct MergingDigest{T, K}
     useTwoLevelCompression
 end
 
-function MergingDigest(compression) 
+function MergingDigest(compression)
     MergingDigest(compression, K_3())
 end
 
-function MergingDigest(compression, scale::ScaleFunction) 
+function MergingDigest(compression, scale::ScaleFunction)
     MergingDigest{Float64, Int64}(compression, 5*compression, true, scale)
 end
 
-function MergingDigest{T,K}(compression) where {T, K} 
+function MergingDigest{T,K}(compression) where {T, K}
     MergingDigest{T, K}(compression, K_3())
 end
 
-function MergingDigest{T,K}(compression, scale::ScaleFunction) where {T, K} 
+function MergingDigest{T,K}(compression, scale::ScaleFunction) where {T, K}
     MergingDigest{T, K}(compression, 5*compression, true, scale)
 end
 
@@ -121,7 +123,7 @@ end
 function max_step(digest::MergingDigest, q::Number, private=true)
     compression = private ? digest.privateCompression : digest.publicCompression
     max_step(digest.scale, q, compression, length(digest))
-end    
+end
 
 function fit!(digest::MergingDigest{T, K}, vals::AbstractVector{<:Number}) where {T, K}
     if length(vals) > 10_000
@@ -133,7 +135,7 @@ function fit!(digest::MergingDigest{T, K}, vals::AbstractVector{<:Number}) where
         if any(isnan.(vals))
             throw(ArgumentError("Cannot add NaN to t-digest"))
         end
-        
+
         digest.totalWeight[1] += length(vals)
         if length(vals) + length(digest.sketch) > digest.maxSize
             tmp = copy(digest.sketch)
@@ -144,10 +146,10 @@ function fit!(digest::MergingDigest{T, K}, vals::AbstractVector{<:Number}) where
             else
                 log = digest.log
             end
-            
-            # merging on a temporary copy of the data avoids excess expansion of the sketch itself 
+
+            # merging on a temporary copy of the data avoids excess expansion of the sketch itself
             mergeNewValues!(digest, tmp, log, false, digest.privateCompression)
-            
+
             copy!(digest.sketch, copy(tmp))
             copy!(digest.log, log)
         else
@@ -157,7 +159,7 @@ function fit!(digest::MergingDigest{T, K}, vals::AbstractVector{<:Number}) where
     return
 end
 
-function fit!(digest::MergingDigest{T, K}, x) where {T, K}
+function OnlineStatsBase._fit!(digest::MergingDigest{T, K}, x) where {T, K}
     if isnan(x)
         throw(ArgumentError("Cannot add NaN to t-digest"))
     end
@@ -172,7 +174,7 @@ function fit!(digest::MergingDigest{T, K}, x) where {T, K}
     return
 end
 
-function merge!(digest::MergingDigest, other::MergingDigest)
+function OnlineStatsBase._merge!(digest::MergingDigest, other::MergingDigest)
     if digest.logData && !other.logData
         throw(ArgumentError("Can't merge a digest that hasn't logged samples to one that has"))
     end
@@ -199,19 +201,21 @@ function merge!(digest::MergingDigest, other::MergingDigest)
     end
 end
 
+OnlineStatsBase.nobs(digest::MergingDigest) = sum(x -> x.count, digest.sketch, init=0)
+
 mergeNewValues!(digest::MergingDigest, force::Bool, compression) =
     mergeNewValues!(digest, digest.sketch, digest.log, force, compression)
 
 md"""
-Merge the clusters of a t-digest as much as possible. This has no effect 
+Merge the clusters of a t-digest as much as possible. This has no effect
 if not enough data has been added since the last merge unless the merge
 is forced.
 
-The order of the clusters after this operation is either perfectly ascending 
+The order of the clusters after this operation is either perfectly ascending
 or perfectly descending except if the merge is forced, then the result is
 always in ascending order.
 """
-function mergeNewValues!(digest::MergingDigest, sketch::Vector, log::Vector, force::Bool, compression) 
+function mergeNewValues!(digest::MergingDigest, sketch::Vector, log::Vector, force::Bool, compression)
     if length(sketch) < 2
         # nothing to do
         return
@@ -231,7 +235,7 @@ function mergeNewValues!(digest::MergingDigest, sketch::Vector, log::Vector, for
         if !reverse && length(sketch) < compression && issorted(sketch)
             return
         end
-        
+
         digest.mergeCount[1] += 1
 
         # now pass through the data merging clusters where possible
@@ -239,7 +243,7 @@ function mergeNewValues!(digest::MergingDigest, sketch::Vector, log::Vector, for
         total = digest.totalWeight[1]
         norm = normalizer(digest.scale, compression, total)
 
-        length(sketch) ≥ 2 || throw(AssertionError("Impossible")) 
+        length(sketch) ≥ 2 || throw(AssertionError("Impossible"))
 
         # w_so_far is total count up to and including `sketch[to]`
         # k0 is the scale up to but not including `sketch[to]`
@@ -248,11 +252,11 @@ function mergeNewValues!(digest::MergingDigest, sketch::Vector, log::Vector, for
         w_so_far += sketch[2].count
         to = 2
         from = 3
-        # the limiting weight is computed by finding a diff of 1 in scale 
+        # the limiting weight is computed by finding a diff of 1 in scale
         limit = total * q_scale(digest.scale, k0 + 1, norm)
         while from <= length(sketch)
             from > to || throw(AssertionError("from ≤ to"))
-            
+
             dw = sketch[from].count
             if w_so_far + dw > limit || from == length(sketch)
                 # can't merge due to size or due to forcing singleton at end
@@ -299,7 +303,7 @@ function merge(a::Centroid{T, K}, b::Centroid{T, K}) where {T, K}
 end
 
 md"""
-Scans a digest to verify that the digest invariant is satisfied without 
+Scans a digest to verify that the digest invariant is satisfied without
 compressing or sorting the data in the digest.
 """
 function checkWeights(digest::MergingDigest)
@@ -320,9 +324,9 @@ function checkWeights(digest::MergingDigest)
         length(digest.log) == 0 ||
             throw(AssertionError("Digest has shouldn't have logged samples"))
     end
-            
+
     tmp = sort(digest.sketch)
-    
+
     (tmp[1].count == 1 && tmp[end].count == 1) ||
         @error "debug" tmp[1] tmp[end]
 
@@ -330,8 +334,8 @@ function checkWeights(digest::MergingDigest)
     norm = normalizer(digest.scale, digest.privateCompression, digest.totalWeight[1])
     q1 = 0
     k1 = k_scale(scale, q1, norm)
-    
-    
+
+
     i = 0
     for c in tmp
         i += 1
@@ -357,7 +361,7 @@ be doing all the time. It is best done only when we want to persist the digest.
 compress(digest::MergingDigest) = mergeNewValues!(digest, true, digest.publicCompression)
 
 Base.length(digest::MergingDigest) = length(digest.sketch)
-         
+
 md"""
 Approximate the value of the empirical CDF at a value of `x`.
 """
@@ -384,7 +388,7 @@ function cdf(digest::MergingDigest, x)
         n = length(digest)
         min, max = first(digest.sketch).mean, last(digest.sketch).mean
         total = digest.totalWeight[1]
-        
+
         if x < min
             return 0.0
         elseif x == min
@@ -438,7 +442,7 @@ function cdf(digest::MergingDigest, x)
 
                     # can't have double singleton (handled that earlier)
                     dw > 1 || throw(AssertionError("Can't have double singleton"))
-                    (leftExcludedW + rightExcludedW) <= 0.5 || 
+                    (leftExcludedW + rightExcludedW) <= 0.5 ||
                         throw(AssertionError("Can't have double singleton"))
 
                     # adjust endpoints for any singleton
@@ -485,7 +489,7 @@ function quantile(digest::MergingDigest, q::Number)
     if length(digest.sketch) == 0
         # no centroids means no data, no way to get a quantile
         return NaN
-    elseif length(digest.sketch) == 1 
+    elseif length(digest.sketch) == 1
         # with one data point, all quantiles lead to Rome
         return digest.sketch[1].mean
     end
@@ -580,7 +584,7 @@ function weightedAverageSorted(x1, w1, x2, w2)
     return max(x1, min(x, x2))
 end
 
-            
+
 """
     @Override
     public int byteSize() {
@@ -669,6 +673,6 @@ end
 
     }
 """
-              
+
 
 end # module


### PR DESCRIPTION
I meant for this PR to have a small diff to highlight how the OnlineStatsBase interface works, but my text editor automatically removed a lot of whitespace. 

The main changes are:

1. I made `MergingDigest` a subtype of `OnlineStat{Number}`.
2. I changed `fit!` to `OnlineStatsBase._fit!`.
3. I changed `merge!` to `OnlineStatsBase._merge!`.
4. Add `import Statistics: quantile`
5. Added `OnlineStatsBase.nobs`, `OnlineStatsBase.value`, and `Base.show` methods .

Example of interface in action:

```Julia
julia> o = TDigest.MergingDigest(200);

julia> fit!(o, rand() for i in 1:10^7)
MergingDigest: n=10000000

julia> quantile(o, .9)
0.8998275458628833
```
